### PR TITLE
Fix login function call to use object parameter

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -22,7 +22,7 @@ export default function LoginPage() {
     e.preventDefault()
     setIsLoading(true)
     try {
-      await login(email, password, rememberMe)
+      await login({ email, password, rememberMe })
     } catch (error) {
       console.error('Login failed:', error)
     } finally {


### PR DESCRIPTION
## Purpose
Fix TypeScript compilation error that was preventing successful builds on Vercel. The user encountered a build failure where the login function was being called with 3 separate arguments instead of the expected single object parameter, causing the build to fail with "Expected 1 arguments, but got 3" error.

## Code changes
- Updated login function call in `src/app/(auth)/login/page.tsx` to pass parameters as a single object `{ email, password, rememberMe }` instead of three separate arguments
- This resolves the TypeScript type mismatch and allows the build to complete successfully on Vercel

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c6dad328f3aa463983f1b4d429b610f4/neon-garden)

👀 [Preview Link](https://c6dad328f3aa463983f1b4d429b610f4-neon-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c6dad328f3aa463983f1b4d429b610f4</projectId>-->
<!--<branchName>neon-garden</branchName>-->