### PR TITLE
Fix socket connection to use socketEndpoint from API

### DIFF
--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -49,7 +49,7 @@ interface StreamData {
 interface StartStreamResponse {
   streamId: number  // API returns streamId, use this for chat payload
   streamKey: string // For socket connection
-  socketEndpoint: string
+  socketEndpoint: string // Use this for WebSocket connection instead of /stream/streamId
   title?: string
   isLive?: boolean
 }
@@ -432,6 +432,7 @@ export default function StreamPage() {
                     avatar: user?.avatar
                   }
                 } as StreamResponse}
+                socketEndpoint={currentStream.socketEndpoint}
                 cameraEnabled={cameraEnabled}
                 micEnabled={micEnabled}
                 onStatusChange={handleStreamingStatusChange}

--- a/src/components/streaming/StreamingManager.tsx
+++ b/src/components/streaming/StreamingManager.tsx
@@ -67,17 +67,19 @@ export function StreamingManager({
 
   const initializeStreaming = async () => {
     try {
-      // Use socketEndpoint from API response instead of constructing /stream/streamId
-      const roomId = socketEndpoint || `/stream/${streamData.streamKey}`
-
       const socketConfig: SocketConnectionConfig = {
         accessCode: streamData.streamKey,
         clientType: 'creator',
         streamId: String(streamData.id),
-        streamKey: streamData.streamKey
+        streamKey: streamData.streamKey,
+        socketEndpoint: socketEndpoint  // Pass the socketEndpoint from API response
       }
 
-      console.log('🔌 Using socketEndpoint for connection:', roomId)
+      console.log('🔌 Initializing streaming with config:', {
+        streamId: socketConfig.streamId,
+        streamKey: socketConfig.streamKey,
+        socketEndpoint: socketConfig.socketEndpoint
+      })
 
       setupSocketEventListeners()
       await socketService.connect(socketConfig)

--- a/src/components/streaming/StreamingManager.tsx
+++ b/src/components/streaming/StreamingManager.tsx
@@ -8,6 +8,7 @@ import StreamChatBox from '@/components/chat/StreamChatBox'
 
 interface StreamingManagerProps {
   streamData: StreamResponse
+  socketEndpoint?: string  // Use this instead of /stream/streamId
   cameraEnabled: boolean
   micEnabled: boolean
   onStatusChange: (connected: boolean) => void
@@ -16,6 +17,7 @@ interface StreamingManagerProps {
 
 export function StreamingManager({
   streamData,
+  socketEndpoint,
   cameraEnabled,
   micEnabled,
   onStatusChange,
@@ -65,12 +67,17 @@ export function StreamingManager({
 
   const initializeStreaming = async () => {
     try {
+      // Use socketEndpoint from API response instead of constructing /stream/streamId
+      const roomId = socketEndpoint || `/stream/${streamData.streamKey}`
+
       const socketConfig: SocketConnectionConfig = {
         accessCode: streamData.streamKey,
         clientType: 'creator',
         streamId: String(streamData.id),
         streamKey: streamData.streamKey
       }
+
+      console.log('🔌 Using socketEndpoint for connection:', roomId)
 
       setupSocketEventListeners()
       await socketService.connect(socketConfig)
@@ -82,6 +89,7 @@ export function StreamingManager({
       await setupOptimizedMediaCapture()
 
     } catch (error) {
+      console.error('💥 Streaming initialization error:', error)
       toast.error('Không thể khởi tạo streaming')
       setIsConnected(false)
       scheduleReconnect()

--- a/src/components/streaming/StreamingManager.tsx
+++ b/src/components/streaming/StreamingManager.tsx
@@ -8,7 +8,7 @@ import StreamChatBox from '@/components/chat/StreamChatBox'
 
 interface StreamingManagerProps {
   streamData: StreamResponse
-  socketEndpoint?: string  // Use this instead of /stream/streamId
+  socketEndpoint?: string  
   cameraEnabled: boolean
   micEnabled: boolean
   onStatusChange: (connected: boolean) => void
@@ -54,12 +54,12 @@ export function StreamingManager({
   useEffect(() => {
     if (isRecording && socketService.getIsConnected()) {
       const statsInterval = setInterval(() => {
-        socketService.requestStreamStats(String(streamData.id))
+        socketService.requestStreamStats(String(streamData.streamKey))
       }, 10000)
 
       return () => clearInterval(statsInterval)
     }
-  }, [isRecording, streamData.id])
+  }, [isRecording, streamData.streamKey])
 
   useEffect(() => {
     onStatusChange(isConnected && isRecording)
@@ -326,7 +326,7 @@ export function StreamingManager({
   const sendMp4InitSegment = async (initBuffer: ArrayBuffer) => {
     try {
       if (socketService.getIsConnected()) {
-        await socketService.sendMp4InitSegment(String(streamData.id), initBuffer)
+        await socketService.sendMp4InitSegment(String(streamData.streamKey), initBuffer)
       }
     } catch (error) {
       setBufferHealth(prev => ({ ...prev, failed: prev.failed + 1 }))
@@ -405,7 +405,8 @@ export function StreamingManager({
       try {
         if (socketService.getIsConnected()) {
           const success = await socketService.sendStreamChunk(
-            String(streamData.id),
+            streamData.id,   
+            streamData.streamKey,
             buffer,
             chunkNumber,
             getBestSupportedMimeType()

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -126,24 +126,17 @@ export class SocketService {
     if (config.streamKey) {
       joinData.streamKey = config.streamKey
     }
-
-    // Determine roomId based on user requirements:
-    // - If socketEndpoint is provided, use that (removes leading slash if present)
-    // - Creators: use streamKey for socket connections (streaming ingest)
-    // - Viewers: can use streamId or streamKey depending on what's available
     let roomId: string
     if (config.socketEndpoint) {
-      // Use the socketEndpoint from API response, clean up the path
-      roomId = config.socketEndpoint.startsWith('/') ? config.socketEndpoint.substring(1) : config.socketEndpoint
-      console.log('🔌 Using socketEndpoint as roomId:', roomId)
+      roomId = config.streamKey || 'unknown'
+      console.log('🔌 Đây là streamKey as roomId:', roomId)
     } else if (config.clientType === 'creator') {
-      // For creators, prioritize streamKey for socket connections
-      roomId = config.streamKey || config.streamId || config.accessCode || 'unknown'
-      console.log('🔑 Using streamKey as roomId:', roomId)
+      roomId = config.streamKey || 'unknown'
+      console.log('Đây là streamKey as roomId::', roomId)
     } else {
-      // For viewers, can use either streamId or streamKey
-      roomId = config.streamId || config.streamKey || config.accessCode || 'unknown'
-      console.log('👁️ Using streamId/streamKey as roomId:', roomId)
+      // roomId = config.streamId || config.streamKey || config.accessCode || 'unknown'
+      roomId = config.streamKey || 'unknow'
+      console.log('Đây là streamKey as roomId:', roomId)
     }
 
     if (config.clientType === 'creator' || config.streamId) {
@@ -286,7 +279,7 @@ export class SocketService {
     }
   }
 
-  async sendStreamChunk(streamId: string, chunkData: ArrayBuffer, chunkNumber: number, mimeType: string): Promise<boolean> {
+  async sendStreamChunk(streamId: number, streamKey: string, chunkData: ArrayBuffer, chunkNumber: number, mimeType: string): Promise<boolean> {
     if (!this.socket || !this.isConnected) {
       return false
     }
@@ -294,6 +287,7 @@ export class SocketService {
     try {
       const chunkPayload = {
         streamId: streamId,
+        streamKey: streamKey,
         chunkData: chunkData,
         chunkNumber: chunkNumber,
         mimeType: mimeType,

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -5,6 +5,7 @@ export interface SocketConnectionConfig {
   clientType?: 'creator' | 'viewer' | 'client'
   streamId?: string
   streamKey?: string
+  socketEndpoint?: string  // Use this endpoint path instead of constructing from streamKey
 }
 
 export interface JoinRoomData {
@@ -127,15 +128,22 @@ export class SocketService {
     }
 
     // Determine roomId based on user requirements:
+    // - If socketEndpoint is provided, use that (removes leading slash if present)
     // - Creators: use streamKey for socket connections (streaming ingest)
     // - Viewers: can use streamId or streamKey depending on what's available
     let roomId: string
-    if (config.clientType === 'creator') {
+    if (config.socketEndpoint) {
+      // Use the socketEndpoint from API response, clean up the path
+      roomId = config.socketEndpoint.startsWith('/') ? config.socketEndpoint.substring(1) : config.socketEndpoint
+      console.log('🔌 Using socketEndpoint as roomId:', roomId)
+    } else if (config.clientType === 'creator') {
       // For creators, prioritize streamKey for socket connections
       roomId = config.streamKey || config.streamId || config.accessCode || 'unknown'
+      console.log('🔑 Using streamKey as roomId:', roomId)
     } else {
       // For viewers, can use either streamId or streamKey
       roomId = config.streamId || config.streamKey || config.accessCode || 'unknown'
+      console.log('👁️ Using streamId/streamKey as roomId:', roomId)
     }
 
     if (config.clientType === 'creator' || config.streamId) {


### PR DESCRIPTION
## Purpose

The user identified an issue where the streaming creator was incorrectly connecting to WebSocket using a constructed path `/stream/streamId` instead of using the `socketEndpoint` provided in the API response. The API returns a specific `socketEndpoint` field that should be used for WebSocket connections to ensure proper streaming functionality.

## Code changes

- **Updated `StartStreamResponse` interface**: Added clarifying comment that `socketEndpoint` should be used for WebSocket connection instead of constructing from streamId
- **Modified `StreamingManager` component**: 
  - Added optional `socketEndpoint` prop to receive the endpoint from API response
  - Updated socket configuration to include and pass the `socketEndpoint`
  - Added console logging for debugging socket initialization
- **Enhanced `SocketService`**:
  - Added `socketEndpoint` field to `SocketConnectionConfig` interface
  - Updated connection logic to prioritize `socketEndpoint` when available
  - Added proper path cleaning (removes leading slash) for the endpoint
  - Improved logging to show which endpoint is being used for connection
- **Updated stream page**: Passed `socketEndpoint` from current stream data to `StreamingManager` component

These changes ensure that creators connect to the correct WebSocket endpoint as specified by the API response, fixing the streaming connection issue.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/22a8fb0303ff49719e78702138e20834/neon-realm)

👀 [Preview Link](https://22a8fb0303ff49719e78702138e20834-neon-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>22a8fb0303ff49719e78702138e20834</projectId>-->
<!--<branchName>neon-realm</branchName>-->