### PR TITLE
Fix incoming call reject and self-call filtering

### DIFF
--- a/src/components/IncomingCallModal.tsx
+++ b/src/components/IncomingCallModal.tsx
@@ -153,7 +153,16 @@ export default function IncomingCallModal() {
           </div>
 
           <div className="flex items-center gap-3">
-            <Button size="icon" variant="destructive" onClick={async () => { endPreview(); setOpen(false); setInfo(null); }} className="rounded-full h-12 w-12">
+            <Button size="icon" variant="destructive" onClick={async () => {
+              const room = info.callRoomId
+              if (room) {
+                try { call.rejectCall(room) } catch (e) { console.log('[INCOMING] reject error', e) }
+              }
+              clearIncomingCall()
+              endPreview()
+              setOpen(false)
+              setInfo(null)
+            }} className="rounded-full h-12 w-12">
               <X className="h-5 w-5" />
             </Button>
             <Button size="icon" variant="default" onClick={async () => {


### PR DESCRIPTION
## Purpose
Fix two critical issues in the incoming call interface:
1. Call rejection button was not properly triggering the `rejectCall` function to notify the socket via `call_rejected` event
2. Prevent incoming call notifications from appearing when the user initiates a call themselves (self-call filtering)

## Code changes
- **Added self-call filtering**: Check if the caller ID matches the current user ID and ignore the notification if it's a self-initiated call
- **Fixed call rejection**: Added proper `call.rejectCall(room)` call when the reject button is clicked, along with `clearIncomingCall()` to properly clean up the call state
- **Improved caller ID handling**: Consolidated caller ID extraction from multiple possible payload fields (`callerId`, `callerID`, `fromUserId`, `senderId`)
- **Enhanced error handling**: Added try-catch block around the reject call with logging

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 135`

🔗 [Edit in Builder.io](https://builder.io/app/projects/58e625f76cb243219610f469f9fc27a9/quantum-zone)

👀 [Preview Link](https://58e625f76cb243219610f469f9fc27a9-quantum-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>58e625f76cb243219610f469f9fc27a9</projectId>-->
<!--<branchName>quantum-zone</branchName>-->